### PR TITLE
Add parallel file scanning with progress

### DIFF
--- a/src/main/java/com/beartell/search/FileScanner.java
+++ b/src/main/java/com/beartell/search/FileScanner.java
@@ -6,7 +6,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 /**
  * Utility to recursively scan the file system and collect file metadata.
@@ -27,28 +33,47 @@ public class FileScanner {
         }
     }
 
-    private final List<FileInfo> files = new ArrayList<>();
+    private final List<FileInfo> files = Collections.synchronizedList(new ArrayList<>());
 
     public List<FileInfo> getFiles() {
         return files;
     }
 
-    public void scan() {
+    public void scan(Consumer<Integer> progress) {
         File[] roots = File.listRoots();
+        ExecutorService exec = Executors.newVirtualThreadPerTaskExecutor();
+        AtomicInteger finished = new AtomicInteger();
+        int total = roots.length == 0 ? 1 : roots.length;
+
         for (File root : roots) {
-            scanDirectory(root.toPath());
+            Path path = root.toPath();
+            exec.submit(() -> {
+                scanDirectory(path, exec);
+                int done = finished.incrementAndGet();
+                if (progress != null) {
+                    int percent = (int) ((done * 100.0) / total);
+                    progress.accept(percent);
+                }
+            });
+        }
+
+        exec.shutdown();
+        try {
+            exec.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 
-    private void scanDirectory(Path path) {
+    private void scanDirectory(Path path, ExecutorService exec) {
         if (!Files.isReadable(path)) {
             return;
         }
-        try {
-            Files.list(path).forEach(p -> {
+        try (var stream = Files.list(path)) {
+            stream.forEach(p -> {
                 try {
                     if (Files.isDirectory(p)) {
-                        scanDirectory(p);
+                        exec.submit(() -> scanDirectory(p, exec));
                     } else {
                         BasicFileAttributes attrs = Files.readAttributes(p, BasicFileAttributes.class);
                         String name = p.getFileName().toString();


### PR DESCRIPTION
## Summary
- use virtual threads in `FileScanner` to scan disk roots concurrently
- report scanning progress back to the GUI
- display wait cursor and progress bar while scanning
- scan action now runs in a `SwingWorker` to keep UI responsive

## Testing
- `javac $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_685d64edf47c83298383b8b4defd6cc5